### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/source_code/DibHelper.cpp
+++ b/source_code/DibHelper.cpp
@@ -22,7 +22,7 @@ extern int show_performance;
 void logToFile(char *log_this) {
     FILE *f;
 	fopen_s(&f, "c:\\temp\\yo2", "a"); // this call fails if using the filter within flash player...
-	fprintf(f, log_this);
+	fprintf(f, "%s\n", log_this);
 	fclose(f);
 }
 
@@ -403,7 +403,7 @@ int GetTrueScreenDepth(HDC hDC) {	// don't think I really use/rely on this metho
 
 int RetDepth = GetDeviceCaps(hDC, BITSPIXEL);
 
-if (RetDepth = 16) { // Find out if this is 5:5:5 or 5:6:5
+if (RetDepth == 16) { // Find out if this is 5:5:5 or 5:6:5
   HBITMAP hBMP = CreateCompatibleBitmap(hDC, 1, 1);
 
   HBITMAP hOldBMP = (HBITMAP)SelectObject(hDC, hBMP); // TODO do we need to delete this?


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V559](https://www.viva64.com/en/w/v559/) Suspicious assignment inside the condition expression of 'if' operator: RetDepth = 16. dibhelper.cpp 406
[V618](https://www.viva64.com/en/w/v618/) It's dangerous to call the 'fprintf' function in such a manner, as the line being passed could contain format specification. The example of the safe code: printf("%s", str); dibhelper.cpp 25